### PR TITLE
gnugo timeout, relative import

### DIFF
--- a/board_evaluation/model_eval.py
+++ b/board_evaluation/model_eval.py
@@ -1,5 +1,5 @@
 import tensorflow as tf
-import go_datafile_reader
+from . import go_datafile_reader
 
 #Visual the outputs of the model.
 #Feature_cube: the x input of model, currently assumes first 6 planes are board position features

--- a/munge/finish_games.py
+++ b/munge/finish_games.py
@@ -3,23 +3,22 @@
 
 
 import subprocess
-import threading.Timer
+import threading
 import re
 import os
 import numpy as np
 import gomill
 import gomill.sgf
 import sys
-sys.path.append("/home/justin/Programming/GoAI/kgsgo-dataset-preprocessor")
-import GoBoard
+from ..thirdparty import GoBoard
 
 
 
 #sgf_filepath - str, path to the sgf file we need to complete
 #gnugo will write the resutls to dest_file
 #returns True if successful and False if something went wrong
-def finish_sgf(sgf_filepath, dest_file, board_size = 19, difference_threshold = 6, year_lowerbound = 0
-               gnugo_timeout=10):
+def finish_sgf(sgf_filepath, dest_file, board_size=19, difference_threshold=6,
+               year_lowerbound=0, gnugo_timeout=10):
 
 
     sgf_file = open(sgf_filepath, 'r')

--- a/munge/finish_games.py
+++ b/munge/finish_games.py
@@ -3,6 +3,7 @@
 
 
 import subprocess
+import threading.Timer
 import re
 import os
 import numpy as np
@@ -17,7 +18,8 @@ import GoBoard
 #sgf_filepath - str, path to the sgf file we need to complete
 #gnugo will write the resutls to dest_file
 #returns True if successful and False if something went wrong
-def finish_sgf(sgf_filepath, dest_file, board_size = 19, difference_threshold = 6, year_lowerbound = 0):
+def finish_sgf(sgf_filepath, dest_file, board_size = 19, difference_threshold = 6, year_lowerbound = 0
+               gnugo_timeout=10):
 
 
     sgf_file = open(sgf_filepath, 'r')
@@ -69,7 +71,12 @@ def finish_sgf(sgf_filepath, dest_file, board_size = 19, difference_threshold = 
     #we call gnugo with the appropriate flags to finish the game. gnugo will write the results to dest_file
     p = subprocess.Popen(["gnugo", "-l", sgf_filepath, "--outfile", dest_file, \
             "--score", "aftermath", "--capture-all-dead", "--chinese-rules"], stdout = subprocess.PIPE)
-    output, err = p.communicate() #gnugo will print the final score, we check this with whats written in the sgffile
+    timer = threading.Timer(gnugo_timeout, p.kill)
+    try:
+        timer.start()
+        output, err = p.communicate() #gnugo will print the final score, we check this with whats written in the sgffile
+    finally:
+        timer.cancel()
     m = re.search(r"([A-Za-z]+) wins by ([0-9\.]+) points", output)
     if m is None:
         return False

--- a/munge/go_dataset_preprocessor.py
+++ b/munge/go_dataset_preprocessor.py
@@ -26,7 +26,7 @@ import argparse
 import json
 import sys,os,time, os.path
 import shutil
-from thirdparty import GoBoard
+from ..thirdparty import GoBoard
 import signal
 from os import sys, path
 #mydir = path.dirname(path.abspath(__file__))
@@ -37,8 +37,8 @@ import gomill.sgf
 
 import random
 import numpy as np
-from munge import finish_games
-from  munge import bit_writer
+from . import finish_games
+from . import bit_writer
 
 
 def addToDataFile( datafile, color, move, goBoard, ownership, black_ownership, white_ownership ):

--- a/visualization/BoardEvaluator.py
+++ b/visualization/BoardEvaluator.py
@@ -1,8 +1,7 @@
 #BoardEvaluator.py
 import tensorflow as tf
 import sys
-sys.path.append("../board_evaluation")
-import model
+from ..board_evaluation import model
 import numpy as np
 
 def _board_to_feature_cube(goBoard, color_to_move):

--- a/visualization/main.py
+++ b/visualization/main.py
@@ -15,7 +15,7 @@ import re
 import random
 import numpy as np
 import os
-from GoDriver import GoDriver
+from .GoDriver import GoDriver
 
 MODEL_PATH = "../../data/working/board_eval_cnn_5layer.ckpt"
 


### PR DESCRIPTION
Sub-modules must be imported as part of the GoCNN package, i.e. `from GoCNN.thirdparty import GoBoard`, in order for relative import to work.
